### PR TITLE
Enhance command to handle contenteditable elements

### DIFF
--- a/spec/cypress/integration/example.spec.ts
+++ b/spec/cypress/integration/example.spec.ts
@@ -15,20 +15,65 @@ describe('testing example page', () => {
     cy.get('#simple-text-area').should('have.value', 'Some text')
   })
 
-  it('should append to content editable div by default', () => {
+  it('should respect overwrite options for a simple input', () => {
+    cy.get('#simple-input').fill('Some text', { overwrite: false })
+
+    cy.get('#simple-input').should('have.value', 'Default TextSome text')
+  })
+
+  it('should respect overwrite options for a simple text area', () => {
+    cy.get('#simple-text-area').fill('Some text', { overwrite: false })
+
+    cy.get('#simple-text-area').should('have.value', 'Default TextSome text')
+  })
+  it('should respect overwrite and prepend options for a simple input', () => {
+    cy.get('#simple-input').fill('Some text', {
+      overwrite: false,
+      prepend: true
+    })
+
+    cy.get('#simple-input').should('have.value', 'Some textDefault Text')
+  })
+
+  it('should respect overwrite and prepend options for a simple text area', () => {
+    cy.get('#simple-text-area').fill('Some text', {
+      overwrite: false,
+      prepend: true
+    })
+
+    cy.get('#simple-text-area').should('have.value', 'Some textDefault Text')
+  })
+
+  it('should overwrite content editable elements by default', () => {
     cy.get('#content-editable-div-append').fill('Some text')
 
     cy.get('#content-editable-div-append').should('contain.text', 'Some text')
+    cy.get('#content-editable-div-append').should(
+      'not.contain.text',
+      'Content Editable'
+    )
   })
 
-  it('should overwrite a content editable div', () => {
+  it('should respect overwrite options for a content editable element', () => {
     cy.get('#content-editable-div-overwrite').fill('Some other text', {
-      overwrite: true
+      overwrite: false
     })
 
     cy.get('#content-editable-div-overwrite').should(
       'contain.text',
-      'Some other text'
+      'Content EditableSome other text'
+    )
+  })
+
+  it('should respect overwrite and prepend options for a content editable element', () => {
+    cy.get('#content-editable-div-overwrite').fill('Some other text', {
+      overwrite: false,
+      prepend: true
+    })
+
+    cy.get('#content-editable-div-overwrite').should(
+      'contain.text',
+      'Some other textContent Editable'
     )
   })
 })

--- a/spec/cypress/integration/example.spec.ts
+++ b/spec/cypress/integration/example.spec.ts
@@ -14,4 +14,21 @@ describe('testing example page', () => {
 
     cy.get('#simple-text-area').should('have.value', 'Some text')
   })
+
+  it('should append to content editable div by default', () => {
+    cy.get('#content-editable-div-append').fill('Some text')
+
+    cy.get('#content-editable-div-append').should('contain.text', 'Some text')
+  })
+
+  it('should overwrite a content editable div', () => {
+    cy.get('#content-editable-div-overwrite').fill('Some other text', {
+      overwrite: true
+    })
+
+    cy.get('#content-editable-div-overwrite').should(
+      'contain.text',
+      'Some other text'
+    )
+  })
 })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,11 +1,12 @@
 declare namespace Cypress {
   interface Chainable {
     /**
-     * Fills an input or textarea element.
+     * Fills an input, textarea, or contenteditable element.
      * @param value - Text to be filled
+     * @param options
      * @example
      *    cy.get('#the-element-id').fill('Some text')
      */
-    fill(value: string): Chainable<void>
+    fill(value: string, options: { overwrite?: boolean }): Chainable<void>
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,8 @@
 declare namespace Cypress {
+  interface FillOptions {
+    overwrite?: boolean
+    prepend?: boolean
+  }
   interface Chainable {
     /**
      * Fills an input, textarea, or contenteditable element.
@@ -7,6 +11,6 @@ declare namespace Cypress {
      * @example
      *    cy.get('#the-element-id').fill('Some text')
      */
-    fill(value: string, options: { overwrite?: boolean }): Chainable<void>
+    fill(value: string, options?: FillOptions): Chainable<void>
   }
 }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -8,5 +8,7 @@
   <body>
     <input id="simple-input" />
     <textarea id="simple-text-area"></textarea>
+    <div id="content-editable-div-append" contenteditable="true">Content Editable</div>
+    <div id="content-editable-div-overwrite" contenteditable="true">Content Editable</div>
   </body>
 </html>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -6,8 +6,8 @@
     <title>Document</title>
   </head>
   <body>
-    <input id="simple-input" />
-    <textarea id="simple-text-area"></textarea>
+    <input id="simple-input" value="Default Text" />
+    <textarea id="simple-text-area">Default Text</textarea>
     <div id="content-editable-div-append" contenteditable="true">Content Editable</div>
     <div id="content-editable-div-overwrite" contenteditable="true">Content Editable</div>
   </body>


### PR DESCRIPTION
This PR adds the ability to fill elements that have the contenteditable attribute set. This is needed in general for contenteditable elements and in my specific use case to update the value of FROALA editor instances.