### PR TITLE
Return element to make it chainable downstream

### DIFF
--- a/spec/cypress/integration/example.spec.ts
+++ b/spec/cypress/integration/example.spec.ts
@@ -76,4 +76,10 @@ describe('testing example page', () => {
       'Some other textContent Editable'
     )
   })
+
+  it('should be chainable to future child commands', () => {
+    cy.get('#simple-text-area').fill('Some text').clear()
+
+    cy.get('#simple-text-area').should('have.value', '')
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,5 +74,7 @@ Cypress.Commands.add(
         }
       }
     })
+
+    cy.wrap(element)
   }
 )


### PR DESCRIPTION
cy.type(text) returns the element so that other operations can happen.

Example of a simple form on a complex page with no easy selectors on the button:

```
cy.get('input[name="myinput"]')
      .clear()
      .fill(newText)
      .siblings('button').click()
```